### PR TITLE
FIX: python 3.12 deprecation of failUnless in test

### DIFF
--- a/recipe/4_fix_failUnlessEqual.patch
+++ b/recipe/4_fix_failUnlessEqual.patch
@@ -1,0 +1,23 @@
+--- test_ed25519_kat.py 2024-02-18 10:01:51.005609521 -0600
++++ test_ed25519_kat.py     2024-02-18 10:02:18.218133143 -0600
+@@ -31,15 +31,15 @@
+
+             sk = ed25519_blake2b.SigningKey(seed)
+             vk = sk.get_verifying_key()
+-            self.failUnlessEqual(vk.to_bytes(), vk_s)
++            self.assertEqual(vk.to_bytes(), vk_s)
+             vk2 = ed25519_blake2b.VerifyingKey(vk_s)
+-            self.failUnlessEqual(vk2, vk) # objects should compare equal
+-            self.failUnlessEqual(vk2.to_bytes(), vk_s)
++            self.assertEqual(vk2, vk) # objects should compare equal
++            self.assertEqual(vk2.to_bytes(), vk_s)
+             newsig = sk.sign(msg)
+             sig_R,sig_S = sig[:32],sig[32:]
+             newsig_R,newsig_S = newsig[:32],newsig[32:]
+-            self.failUnlessEqual(hexlify(newsig), hexlify(sig)) # deterministic sigs
+-            self.failUnlessEqual(vk.verify(sig, msg), None) # no exception
++            self.assertEqual(hexlify(newsig), hexlify(sig)) # deterministic sigs
++            self.assertEqual(vk.verify(sig, msg), None) # no exception
+
+
+ if __name__ == '__main__':

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
